### PR TITLE
Wait for userData to be fetched before filling globalValues in dataLayer

### DIFF
--- a/resources/views/TrackingCode.twig
+++ b/resources/views/TrackingCode.twig
@@ -1143,32 +1143,34 @@ const NEWSLETTER_OPT_IN         = "newsletter-opt-in";
 
 			{% set webstoreName = webstoreConfig.name|trim|raw %}
 
-			var userData = ceresStore.state.user.userData;
-			var userDataEmail = "";
-			var userDataId = 0;
-			if(userData !== null) {
-				userDataEmail = userData.email;
-				userDataId = userData.id;
-			}
+			// Cache original setter.
+			let originalSetter = Object.getOwnPropertyDescriptor(ceresStore.state.user, 'userData').set;
 
-			dataLayer.push ({
-				"event": "globalValues",
-				"currency": "{{ currencyData.name }}",
-				"lang": "{{ lang }}",
-				"pageType": "{{ pageType }}",
-				{% if '"' in webstoreName == true and "'" in webstoreName == false %}
-				"webstoreName": '{{ webstoreConfig.name|trim|raw }}',
-				{% elseif '"' in webstoreName == false and "'" in webstoreName == true %}
-				"webstoreName": "{{ webstoreConfig.name|trim|raw }}",
-				{% elseif '"' in webstoreName == true and "'" in webstoreName == true %}
-				"webstoreName": "{{ webstoreConfig.name|trim }}",
-				{% else %}
-				"webstoreName": "{{ webstoreConfig.name|trim|raw }}",
-				{% endif %}
-				"customerEmail": userDataEmail,
-				"customerId": userDataId,
-				"basketItems": basketItems,
-				"basketData": basketData
+			// Define new setter to fill globalValues in dataLayer when userData was asynchronously fetched.
+			Object.defineProperty(ceresStore.state.user, 'userData', {
+				set(userData) {
+					originalSetter.call(this, userData);
+
+					dataLayer.push ({
+						"event": "globalValues",
+						"currency": "{{ currencyData.name }}",
+						"lang": "{{ lang }}",
+						"pageType": "{{ pageType }}",
+						{% if '"' in webstoreName == true and "'" in webstoreName == false %}
+						"webstoreName": '{{ webstoreConfig.name|trim|raw }}',
+						{% elseif '"' in webstoreName == false and "'" in webstoreName == true %}
+						"webstoreName": "{{ webstoreConfig.name|trim|raw }}",
+						{% elseif '"' in webstoreName == true and "'" in webstoreName == true %}
+						"webstoreName": "{{ webstoreConfig.name|trim }}",
+						{% else %}
+						"webstoreName": "{{ webstoreConfig.name|trim|raw }}",
+						{% endif %}
+						"customerEmail": userData?.email ?? "",
+						"customerId": userData?.id ?? 0,
+						"basketItems": basketItems,
+						"basketData": basketData
+					});
+				}
 			});
 
 			openBasketPreview();


### PR DESCRIPTION
Refactored the way we handle user data in the TrackingCode.twig file by introducing a new setter. This setter ensures that globalValues in the dataLayer are updated with the correct userData after it has been fetched asynchronously. This change makes sure that all user data are correctly represented, even when fetched late, improving the accuracy of tracking and data analysis.